### PR TITLE
Fixed an incorrect comment

### DIFF
--- a/osquery/tables/system/windows/logon_sessions.cpp
+++ b/osquery/tables/system/windows/logon_sessions.cpp
@@ -88,6 +88,6 @@ QueryData queryLogonSessions(QueryContext& context) {
     }
   }
   return results;
-} // namespace tables
+} // function queryLogonSessions
 } // namespace tables
 } // namespace osquery


### PR DESCRIPTION
Comment stated that closing brace was for the tables namespace, but it was actually for the queryLogonSessions function.